### PR TITLE
Remove reliance on CamelCase component names

### DIFF
--- a/flake8_idom_hooks/utils.py
+++ b/flake8_idom_hooks/utils.py
@@ -1,6 +1,6 @@
 import ast
 from contextlib import contextmanager
-from typing import List, Tuple, Iterator, Any
+from typing import Any, Iterator, List, Tuple
 
 
 @contextmanager
@@ -33,7 +33,7 @@ def is_component_def(node: ast.FunctionDef) -> bool:
     )
 
 
-def is_idom_component_decorator(node) -> bool:
+def is_idom_component_decorator(node: Any) -> bool:
     return getattr(node, "id", None) == "component" or (
         getattr(getattr(node, "value", None), "id", None) == "idom"
         and getattr(node, "attr", None) == "component"

--- a/flake8_idom_hooks/utils.py
+++ b/flake8_idom_hooks/utils.py
@@ -29,8 +29,14 @@ def is_hook_def(node: ast.FunctionDef) -> bool:
 
 def is_component_def(node: ast.FunctionDef) -> bool:
     return any(
-        decorator.value.id == "idom" and decorator.attr == "component"
-        for decorator in node.decorator_list
+        is_idom_component_decorator(decorator) for decorator in node.decorator_list
+    )
+
+
+def is_idom_component_decorator(node) -> bool:
+    return getattr(node, "id", None) == "component" or (
+        getattr(getattr(node, "value", None), "id", None) == "idom"
+        and getattr(node, "attr", None) == "component"
     )
 
 

--- a/flake8_idom_hooks/utils.py
+++ b/flake8_idom_hooks/utils.py
@@ -28,7 +28,10 @@ def is_hook_def(node: ast.FunctionDef) -> bool:
 
 
 def is_component_def(node: ast.FunctionDef) -> bool:
-    return any(decorator.value.id == "idom" for decorator in node.decorator_list)
+    return any(
+        decorator.value.id == "idom" and decorator.attr == "component"
+        for decorator in node.decorator_list
+    )
 
 
 def is_hook_function_name(name: str) -> bool:

--- a/flake8_idom_hooks/utils.py
+++ b/flake8_idom_hooks/utils.py
@@ -35,11 +35,4 @@ def is_component_def(node: ast.FunctionDef) -> bool:
 
 
 def is_hook_function_name(name: str) -> bool:
-    return name.lstrip("_") in {
-        "use_state",
-        "use_effect",
-        "use_memo",
-        "use_reducer",
-        "use_callback",
-        "use_ref",
-    }
+    return name.lstrip("_").startswith("use_")

--- a/flake8_idom_hooks/utils.py
+++ b/flake8_idom_hooks/utils.py
@@ -28,12 +28,15 @@ def is_hook_def(node: ast.FunctionDef) -> bool:
 
 
 def is_component_def(node: ast.FunctionDef) -> bool:
-    return is_component_function_name(node.name)
-
-
-def is_component_function_name(name: str) -> bool:
-    return name[0].upper() == name[0] and "_" not in name
+    return any(decorator.value.id == "idom" for decorator in node.decorator_list)
 
 
 def is_hook_function_name(name: str) -> bool:
-    return name.lstrip("_").startswith("use_")
+    return name.lstrip("_") in {
+        "use_state",
+        "use_effect",
+        "use_memo",
+        "use_reducer",
+        "use_callback",
+        "use_ref",
+    }

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+idom

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,2 @@
 pytest
 pytest-cov
-idom

--- a/tests/hook_usage_test_cases.py
+++ b/tests/hook_usage_test_cases.py
@@ -1,3 +1,4 @@
+import idom
 from idom import component
 
 
@@ -88,16 +89,14 @@ def HookInWhileLoop():
         use_state
 
 
-@component
 def outer_function():
     # error: ROH100 hook 'use_state' defined as closure in function 'outer_function'
-    @component
     def use_state():
         ...
 
 
-@component
 def generic_function():
+
     # error: ROH101 hook 'use_state' used outside component or hook definition
     use_state
 
@@ -109,6 +108,11 @@ def use_state():
 
 @component
 def Component():
+    use_state
+
+
+@idom.component
+def IdomLongImportComponent():
     use_state
 
 
@@ -124,7 +128,6 @@ module.use_state.other
 module.use_effect()
 
 
-@component
 def not_hook_or_component():
     # error: ROH101 hook 'use_state' used outside component or hook definition
     use_state
@@ -187,41 +190,34 @@ def CheckEffects():
     )
 
     @use_effect(args=[x])
-    @component
     def my_effect():
         x
 
     @use_effect(args=[])
-    @component
     def my_effect():
         # error: ROH203 dependency 'x' of function 'my_effect' is not specified in declaration of 'use_effect'
         x
 
     @use_effect(args=[])
     @some_other_deco_that_adds_args_to_func_somehow
-    @component
     def my_effect(*args, **kwargs):
         args
         kwargs
 
     @module.use_effect(args=[])
-    @component
     def my_effect():
         # error: ROH203 dependency 'x' of function 'my_effect' is not specified in declaration of 'use_effect'
         x
 
     @not_a_decorator_we_care_about
-    @component
     def some_func():
         ...
 
     @not_a_decorator_we_care_about()
-    @component
     def some_func():
         ...
 
     @use_effect
-    @component
     def impropper_usage_of_effect_as_decorator():
         # ignored because bad useage
         x

--- a/tests/hook_usage_test_cases.py
+++ b/tests/hook_usage_test_cases.py
@@ -1,9 +1,14 @@
+from idom import component
+
+
+@component
 def HookInIf():
     if True:
         # error: ROH102 hook 'use_state' used inside if statement
         use_state
 
 
+@component
 def HookInElif():
     if False:
         pass
@@ -12,6 +17,7 @@ def HookInElif():
         use_state
 
 
+@component
 def HookInElse():
     if False:
         pass
@@ -20,6 +26,7 @@ def HookInElse():
         use_state
 
 
+@component
 def HookInIfExp():
     (
         # error: ROH102 hook 'use_state' used inside inline if expression
@@ -29,6 +36,7 @@ def HookInIfExp():
     )
 
 
+@component
 def HookInElseOfIfExp():
     (
         None
@@ -39,6 +47,7 @@ def HookInElseOfIfExp():
     )
 
 
+@component
 def HookInTry():
     try:
         # error: ROH102 hook 'use_state' used inside try statement
@@ -47,6 +56,7 @@ def HookInTry():
         pass
 
 
+@component
 def HookInExcept():
     try:
         raise ValueError()
@@ -55,6 +65,7 @@ def HookInExcept():
         use_state
 
 
+@component
 def HookInFinally():
     try:
         pass
@@ -63,37 +74,45 @@ def HookInFinally():
         use_state
 
 
+@component
 def HookInForLoop():
     for i in range(3):
         # error: ROH102 hook 'use_state' used inside for loop
         use_state
 
 
+@component
 def HookInWhileLoop():
     while True:
         # error: ROH102 hook 'use_state' used inside while loop
         use_state
 
 
+@component
 def outer_function():
     # error: ROH100 hook 'use_state' defined as closure in function 'outer_function'
+    @component
     def use_state():
         ...
 
 
+@component
 def generic_function():
     # error: ROH101 hook 'use_state' used outside component or hook definition
     use_state
 
 
+@component
 def use_state():
     use_other
 
 
+@component
 def Component():
     use_state
 
 
+@component
 def use_custom_hook():
     use_state
 
@@ -105,11 +124,13 @@ module.use_state.other
 module.use_effect()
 
 
+@component
 def not_hook_or_component():
     # error: ROH101 hook 'use_state' used outside component or hook definition
     use_state
 
 
+@component
 def CheckEffects():
     x = 1
     y = 2
@@ -166,34 +187,41 @@ def CheckEffects():
     )
 
     @use_effect(args=[x])
+    @component
     def my_effect():
         x
 
     @use_effect(args=[])
+    @component
     def my_effect():
         # error: ROH203 dependency 'x' of function 'my_effect' is not specified in declaration of 'use_effect'
         x
 
     @use_effect(args=[])
     @some_other_deco_that_adds_args_to_func_somehow
+    @component
     def my_effect(*args, **kwargs):
         args
         kwargs
 
     @module.use_effect(args=[])
+    @component
     def my_effect():
         # error: ROH203 dependency 'x' of function 'my_effect' is not specified in declaration of 'use_effect'
         x
 
     @not_a_decorator_we_care_about
+    @component
     def some_func():
         ...
 
     @not_a_decorator_we_care_about()
+    @component
     def some_func():
         ...
 
     @use_effect
+    @component
     def impropper_usage_of_effect_as_decorator():
         # ignored because bad useage
         x
@@ -205,8 +233,10 @@ def CheckEffects():
     )
 
 
+@component
 def make_component():
     # nested component definitions are ok.
+    @component
     def NestedComponent():
         use_state
 
@@ -214,6 +244,7 @@ def make_component():
 some_global_variable
 
 
+@component
 def Component():
     # referencing a global variable is OK
     use_effect(lambda: some_global_variable, [])
@@ -221,9 +252,11 @@ def Component():
 
 if True:
 
+    @component
     def Component():
         # this is ok since the conditional is outside the component
         use_state
 
+    @component
     def use_other():
         use_state


### PR DESCRIPTION
`is_component_def` now checks if a function is decorated with `@idom.component` to determine whether something is a component.

This implementation also works if directly using `@component` as a decorator.

Also, all hook names are now explicitly checked for rather than assuming everything `use_*` is a hook.