### PR TITLE
fix false possitive early return errors

### DIFF
--- a/flake8_idom_hooks/rules_of_hooks.py
+++ b/flake8_idom_hooks/rules_of_hooks.py
@@ -42,7 +42,11 @@ class RulesOfHooksVisitor(ast.NodeVisitor):
             ):
                 self.generic_visit(node)
         else:
-            with set_current(self, function=node):
+            with set_current(
+                self,
+                function=node,
+                early_return=None,
+            ):
                 self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:

--- a/tests/cases/hook_usage.py
+++ b/tests/cases/hook_usage.py
@@ -190,3 +190,24 @@ def example():
         return None
     # error: ROH103 hook 'use_state' used after an early return
     use_state()
+
+
+@component
+def example():
+    def closure():
+        # this return is ok since it's not in the same function
+        return None
+
+    # Ok: no early return error
+    use_state()
+
+
+@component
+def example():
+    @use_effect
+    def some_effect():
+        # this return is ok since it's not in the same function
+        return None
+
+    # Ok: no early return error
+    use_state()


### PR DESCRIPTION
Any return statement inside a component triggers early return errors for hook usages that happen afterwards.